### PR TITLE
added support for running with the com.sun.net.ssl.internal.www.protocol package

### DIFF
--- a/src/main/java/com/paypal/core/DefaultHttpConnection.java
+++ b/src/main/java/com/paypal/core/DefaultHttpConnection.java
@@ -69,8 +69,11 @@ public class DefaultHttpConnection extends HttpConnection {
 		if (this.connection instanceof HttpsURLConnection) {
 			((HttpsURLConnection) this.connection)
 					.setSSLSocketFactory(this.sslContext.getSocketFactory());
+		} else if (this.connection instanceof com.sun.net.ssl.HttpsURLConnection) {
+			((com.sun.net.ssl.HttpsURLConnection) this.connection)
+					.setSSLSocketFactory(this.sslContext.getSocketFactory());
 		}
-
+		
 		if (this.config.getProxyUserName() != null
 				&& this.config.getProxyPassword() != null) {
 			final String username = this.config.getProxyUserName();


### PR DESCRIPTION
The DefaultHttpConnection.createAndconfigureHttpConnection is incompatible with the com.sun.net.ssl.internal.www.protocol package as implemented. The two objects are behaviorally similar, but the com.sun.net.ssl.internal.www.protocol.https.HttpsURLConnectionOldImpl dervies from com.sun.net.ssl.HttpsURLConnection, which in turn derives from java.net.HttpURLConnection. The DefaultHttpConnection.createAndconfigureHttpConnection is checking if the connection is an instance of javax.net.ssl.HttpsURLConnection, which derives from java.net.HttpURLConnection. Both objects ultimately share common ancestry of hava.net.HttpURLConnection, and both objects are very similar interface-wise, however, the com.sun.* fails the instanceof test, and as such, even though an SSL connection is being made, the sslContext never gets loaded, and thus client certificates are not presented, which behaviorally results in any invocation of the paypal service resuliting in a "read timed out" exception. 

This change adds a secondary test (if.. else if) to check if the connection is an instance of com.sun.net.ssl.HttpsURLConnection, and if so, casts and adds the sslContext as required.

We were faced with a scenario with an applicaiton which required libraries from other systems, and in this case, one of those libraries requires the use of the com.sun.net.ssl.internal.www.protocol. Unfortunately, however, it seems that within the context of a single JVM, you either use com.sun.net.ssl.internal.www.protocol or the java default of sun.net.www.protocol (one or the other), which is controlled by a system property. There does not seem to be a way to use both side-by-side.

To run a jvm using the alternate package (as an example), add -Djava.protocol.handler.pkgs=com.sun.net.ssl.internal.www.protocol as a command line argument to the JVM, or use System.setProperty("java.protocol.handler.pkgs","com.sun.net.ssl.internal.www.protocol") in your application code.