### PR TITLE
[squid:S1118] Utility classes should not have public constructors

### DIFF
--- a/src/main/java/com/paypal/core/codec/CharEncoding.java
+++ b/src/main/java/com/paypal/core/codec/CharEncoding.java
@@ -123,4 +123,7 @@ public class CharEncoding {
      * @see <a href="http://download.oracle.com/javase/1.5.0/docs/api/java/nio/charset/Charset.html">Standard charsets</a>
      */
     public static final String UTF_8 = "UTF-8";
+
+    private CharEncoding() {
+    }
 }

--- a/src/main/java/com/paypal/core/codec/binary/StringUtils.java
+++ b/src/main/java/com/paypal/core/codec/binary/StringUtils.java
@@ -33,6 +33,9 @@ import com.paypal.core.codec.CharEncoding;
  */
 public class StringUtils {
 
+    private StringUtils() {
+    }
+
     /**
      * Encodes the given string into a sequence of bytes using the ISO-8859-1 charset, storing the result into a new
      * byte array.

--- a/src/test/java/com/paypal/core/ConfigurationUtil.java
+++ b/src/test/java/com/paypal/core/ConfigurationUtil.java
@@ -4,7 +4,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class ConfigurationUtil {
-	
+
+	private ConfigurationUtil() {
+	}
+
 	public static Map<String, String> getSignatureConfiguration() {
 		Map<String, String> initMap = new HashMap<String, String>();
 		initMap.put("acct1.UserName", "jb-us-seller_api1.paypal.com");

--- a/src/test/java/com/paypal/core/DataProviderClass.java
+++ b/src/test/java/com/paypal/core/DataProviderClass.java
@@ -11,6 +11,9 @@ import org.testng.annotations.DataProvider;
 public class DataProviderClass {
 	static ConfigManager conf;
 
+	private DataProviderClass() {
+	}
+
 	@DataProvider(name = "configParams")
 	public static Object[][] configParams() throws FileNotFoundException,
 			IOException {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - “Utility classes should not have public constructors ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.
Ayman Abdelghany.